### PR TITLE
Removed API Reference section from README that was duplicated

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,13 +56,6 @@ Usage Example
 
 See 'examples' folder for full usage demo!
 
-API Reference
-=============
-
-.. toctree::
-   :maxdepth: 2
-
-   api
 
 Contributing
 ============


### PR DESCRIPTION
I've tested this locally and compared the docs to the ones I built locally.