### PR TITLE
separate typing imports try/except from sturct import try/except

### DIFF
--- a/adafruit_fingerprint.py
+++ b/adafruit_fingerprint.py
@@ -30,6 +30,10 @@ from micropython import const
 try:
     from typing import Tuple, List, Union
     from busio import UART
+except ImportError:
+    pass
+
+try:
     import struct
 except ImportError:
     import ustruct as struct


### PR DESCRIPTION
The changes to add type hints accidentally made the module non-importable on circuitpython boards.

I'm not sure whether we need to keep the `ustruct` compatibility (it would only apply to micropython) but go ahead and do so.

Closes: #36