### PR TITLE
Fix download image, character file, and template to the sensor. Edited on the _send_data function.

### DIFF
--- a/adafruit_fingerprint.py
+++ b/adafruit_fingerprint.py
@@ -475,7 +475,10 @@ class Adafruit_Fingerprint:
             self._print_debug("_send_data length:", length)
             packet.append(length >> 8)
             packet.append(length & 0xFF)
-            checksum = _DATAPACKET + (length >> 8) + (length & 0xFF)
+            if left <= 0:
+                checksum = _ENDDATAPACKET + (length >> 8) + (length & 0xFF)
+            else:
+                checksum = _DATAPACKET + (length >> 8) + (length & 0xFF)
 
             # for j in range(len(data[start:end])):
             for j in range(start, end):


### PR DESCRIPTION
Add checksum for the _ENDDATAPACKET on the _send_data function, the previous version only concatenate _DATAPACKET checksum which result in error when downloading image, character file, and template to the sensor.

This fix resolve issue #39 and #41.

Thank you.